### PR TITLE
Fix the dark scroll thumb in the member list

### DIFF
--- a/main.css
+++ b/main.css
@@ -1899,4 +1899,6 @@ dcvarsp
     --background-floating: var(--dark-primary);; /* userpopout background */
     --scrollbar-auto-thumb: var(--brand-experiment);
     --scrollbar-auto-track: #0d0d0d;    
+    --scrollbar-thin-thumb: var(--brand-experiment);;
+    /* --scrollbar-thin-track: #1a1b20; */ /*Discord has this disabled by default */
 }


### PR DESCRIPTION
The theme is using the default color for scroll thumb in the member list
this causes it to be almost not visible
I've added a line so it to uses the theme's scroll thumb color (`brand-experiment`)